### PR TITLE
Issue #38 Fix

### DIFF
--- a/aspnet/RVTR.Account.DataContext/AccountContext.cs
+++ b/aspnet/RVTR.Account.DataContext/AccountContext.cs
@@ -42,20 +42,20 @@ namespace RVTR.Account.DataContext
         new PaymentModel()
         {
           Id = -1,
-          cardExpirationDate = new DateTime(),
-          cardNumber = "xxxx-1234",
-          cardName = "Visa",
-          securityCode = "123",
+          CardExpirationDate = new DateTime(),
+          CardNumber = "xxxx-1234",
+          CardName = "Visa",
+          SecurityCode = "123",
           AccountId = -1
         },
         new PaymentModel()
         {
           Id = 1,
           AccountId = 1,
-          cardExpirationDate = new System.DateTime(2020, 08, 31),
-          cardNumber = "4111111111111111",
-          securityCode = "123",
-          cardName = "user's credit card"
+          CardExpirationDate = new System.DateTime(2020, 08, 31),
+          CardNumber = "4111111111111111",
+          SecurityCode = "123",
+          CardName = "user's credit card"
         }
       );
       modelBuilder.Entity<AddressModel>().HasData
@@ -87,8 +87,8 @@ namespace RVTR.Account.DataContext
         {
           Id = -1,
           Email = "Test@test.com",
-          familyName = "Jones",
-          givenName = "Tom",
+          FamilyName = "Jones",
+          GivenName = "Tom",
           Phone = "1234567891",
           Type = "Adult",
           AccountId = -1
@@ -98,8 +98,8 @@ namespace RVTR.Account.DataContext
           Id = 1,
           AccountId = 1,
           Email = "demo.camper@revature.com",
-          familyName = "familyName",
-          givenName = "givenName",
+          FamilyName = "familyName",
+          GivenName = "givenName",
           Phone = "123-456-7891",
           Type = ""
         }

--- a/aspnet/RVTR.Account.ObjectModel/Models/PaymentModel.cs
+++ b/aspnet/RVTR.Account.ObjectModel/Models/PaymentModel.cs
@@ -11,13 +11,13 @@ namespace RVTR.Account.ObjectModel.Models
   {
     public int Id { get; set; }
 
-    public DateTime cardExpirationDate { get; set; }
+    public DateTime CardExpirationDate { get; set; }
 
-    public string cardNumber { get; set; }
+    public string CardNumber { get; set; }
 
-    public string securityCode { get; set; }
+    public string SecurityCode { get; set; }
 
-    public string cardName { get; set; }
+    public string CardName { get; set; }
 
     public int AccountId { get; set; }
     public AccountModel Account { get; set; }
@@ -29,11 +29,11 @@ namespace RVTR.Account.ObjectModel.Models
     /// <returns></returns>
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
-      if (string.IsNullOrEmpty(cardName))
+      if (string.IsNullOrEmpty(CardName))
       {
         yield return new ValidationResult("cardName cannot be null.");
       }
-      if (string.IsNullOrEmpty(cardNumber))
+      if (string.IsNullOrEmpty(CardNumber))
       {
         yield return new ValidationResult("cardNumber cannot be null.");
       }

--- a/aspnet/RVTR.Account.ObjectModel/Models/ProfileModel.cs
+++ b/aspnet/RVTR.Account.ObjectModel/Models/ProfileModel.cs
@@ -12,9 +12,9 @@ namespace RVTR.Account.ObjectModel.Models
 
     public string Email { get; set; }
 
-    public string familyName { get; set; }
+    public string FamilyName { get; set; }
 
-    public string givenName { get; set; }
+    public string GivenName { get; set; }
 
     public string Phone { get; set; }
 
@@ -35,11 +35,11 @@ namespace RVTR.Account.ObjectModel.Models
       {
         yield return new ValidationResult("Email cannot be null.");
       }
-      if (string.IsNullOrEmpty(familyName))
+      if (string.IsNullOrEmpty(FamilyName))
       {
         yield return new ValidationResult("familyName cannot be null.");
       }
-      if (string.IsNullOrEmpty(givenName))
+      if (string.IsNullOrEmpty(GivenName))
       {
         yield return new ValidationResult("givenName cannot be null.");
       }

--- a/aspnet/RVTR.Account.UnitTesting/Tests/PaymentModelTest.cs
+++ b/aspnet/RVTR.Account.UnitTesting/Tests/PaymentModelTest.cs
@@ -14,9 +14,9 @@ namespace RVTR.Account.UnitTesting.Tests
         new PaymentModel()
         {
           Id = 0,
-          cardName = "name",
-          cardNumber = "1234-1234-1234-1234",
-          securityCode = "111",
+          CardName = "name",
+          CardNumber = "1234-1234-1234-1234",
+          SecurityCode = "111",
           AccountId = 0,
           Account = null,
         }

--- a/aspnet/RVTR.Account.UnitTesting/Tests/ProfileModelTest.cs
+++ b/aspnet/RVTR.Account.UnitTesting/Tests/ProfileModelTest.cs
@@ -15,8 +15,8 @@ namespace RVTR.Account.UnitTesting.Tests
         {
           Id = 0,
           Email = "email@email.com",
-          familyName = "family",
-          givenName = "given",
+          FamilyName = "family",
+          GivenName = "given",
           Phone = "1234567890",
           Type = "Adult",
           AccountId = 0,

--- a/aspnet/RVTR.Account.UnitTesting/Tests/RepositoryTest.cs
+++ b/aspnet/RVTR.Account.UnitTesting/Tests/RepositoryTest.cs
@@ -9,7 +9,7 @@ namespace RVTR.Account.UnitTesting.Tests
   public class RepositoryTest : DataTest
   {
     private readonly AccountModel _account = new AccountModel() { Id = 3 };
-    private readonly ProfileModel _profile = new ProfileModel() { familyName = "FN", givenName = "GN", Id = 3, Email = "anemail@random.com", Phone = "123456789", Type = "" };
+    private readonly ProfileModel _profile = new ProfileModel() { FamilyName = "FN", GivenName = "GN", Id = 3, Email = "anemail@random.com", Phone = "123456789", Type = "" };
     private readonly AddressModel _address = new AddressModel() { Id = 3, AccountId = 3 };
 
     [Fact]


### PR DESCRIPTION
Public property names now coincide with .NET naming conventions. Testing did not show any issues with JSON serialization, but if it does cause issues in the future, add the following to the configuration:
``services.AddControllers().AddJsonOptions(options => options.JsonSerializerOptions.PropertyNameCaseInsensitive = false);``